### PR TITLE
Fixed wrong method call when saving product entity (Magento CE 2.1.1)

### DIFF
--- a/Plugin/Model/Import/Product.php
+++ b/Plugin/Model/Import/Product.php
@@ -384,7 +384,7 @@ class Product extends \Magento\CatalogImportExport\Model\Import\Product
                 }
             }
 
-            $this->_saveProductEntity(
+            $this->saveProductEntity(
                 $entityRowsIn,
                 $entityRowsUp
             )->_saveProductWebsites(


### PR DESCRIPTION
Method _saveProductEntity doesn't exist in Magento Community Edition 2.1.1, which leads to errors when importing products.

The erroneous method call has been corrected. 
This bug also exists in the paid version of the module.

see https://github.com/firebearstudio/importexport/pull/3
