### PR TITLE
Tell Firebear ImportExport to load after Magento ImportExport modules

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,5 +5,10 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Firebear_ImportExport" setup_version="1.0.4" />
+    <module name="Firebear_ImportExport" setup_version="1.0.4">
+        <sequence>
+            <module name="Magento_ImportExport" />
+            <module name="Magento_CatalogImportExport" />
+        </sequence>
+    </module>
 </config>


### PR DESCRIPTION
A module should typically load after it's dependencies.  This ensures that Firebear's modifications in xml files are not overwritten by the base Magento files.