### PR TITLE
Fix crash with invalid data in a multiselect field

### DIFF
--- a/Plugin/Model/Import/Product/Validator.php
+++ b/Plugin/Model/Import/Product/Validator.php
@@ -90,7 +90,7 @@ class Validator extends BaseValidator
                 $this->_addMessages(
                     [
                         sprintf(
-                            $this->context->retrieveMessageTemplate(
+                            $subject->context->retrieveMessageTemplate(
                                 RowValidatorInterface::ERROR_INVALID_ATTRIBUTE_OPTION
                             ),
                             $attrCode


### PR DESCRIPTION
Use `$subject` instead of `$this`, which has not been initialized